### PR TITLE
TASK: Updated help message and added German translation

### DIFF
--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file original="" product-name="Flownative.Anchorlinks" source-language="en" target-language="de" datatype="plaintext">
+		<body>
+			<trans-unit id="copy" xml:space="preserve">
+				<source>Copy link to node</source>
+				<target>Kopiere Link zu diesem Element</target>
+			</trans-unit>
+			<trans-unit id="copied" xml:space="preserve">
+				<source>Copied to clipboard!</source>
+				<target>In Zwischenablage kopiert!</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Translations/de/NodeTypes/AnchorMixin.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/AnchorMixin.xlf
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="Flownative.Anchorlinks" source-language="en" datatype="plaintext">
+	<file original="" product-name="Flownative.Anchorlinks" source-language="en" target-language="de" datatype="plaintext">
 		<body>
 			<trans-unit id="groups.anchor" xml:space="preserve">
 				<source>Anchor</source>
+				<target>Anker</target>
 			</trans-unit>
 			<trans-unit id="properties.sectionId" xml:space="preserve">
 				<source>Section id</source>
+				<target>Abschnitts-ID</target>
 			</trans-unit>
 			<trans-unit id="properties.sectionId.ui.help.message" xml:space="preserve">
 				<source>Fill in the section id, save and click the button below to copy the link to this node. You can paste it like any other link in the text editor or in inspector fields.</source>
+				<target>Abschnitts-ID eingeben, speichern und den unter dem Feld erscheinenden Button klicken um den Link zu diesem Element zu kopieren. Dieser kann wie jeder andere Link im Texteditor oder in Feldern des Inspektors eingefügt werden.</target>
 			</trans-unit>
 		</body>
 	</file>


### PR DESCRIPTION
The help message mentioned Aloha. Since 1) Aloha will be replaced by CKEditor in the future and 2) you can also use the link in the inspector (`reference(s)` type properties), I changed the wording a little bit.